### PR TITLE
re-render routes, if no match already.

### DIFF
--- a/src/lib/router-slot.ts
+++ b/src/lib/router-slot.ts
@@ -180,12 +180,17 @@ export class RouterSlot<D = any, P = any>
 	 * @param routes
 	 * @param navigate
 	 */
-	add(
-		routes: IRoute<D>[],
-		navigate: boolean = this.isRoot && this.isConnected
-	): void {
+	add(routes: IRoute<D>[], navigate?: boolean): void {
 		// Add the routes to the array
 		this._routes.push(...routes);
+
+		if (navigate === undefined) {
+			// If navigate is not determined, then we will check if we have a route match. If not then we will re-render.
+			navigate = this._routeMatch === null;
+		}
+
+		// Navigate fallback:
+		navigate ??= this.isRoot && this.isConnected;
 
 		// Register that the path has changed so the correct route can be loaded.
 		if (navigate) {


### PR DESCRIPTION
In our async environment, we often experience routes coming a long over time. Meaning that the first or first few times the routes are set we might not have the right route of this slot just jet. So to accommodate that we should re-render everytime routes are set. If we have no match already.